### PR TITLE
Fixed duplicate link rel canonical

### DIFF
--- a/src/meta_tags.js
+++ b/src/meta_tags.js
@@ -56,6 +56,9 @@ class MetaTags extends Component {
         } else if (tag === 'meta') {
           const meta = getDuplicateMeta(child);
           if (meta) removeChild(head, meta);
+        } else if (tag === 'link' && child.rel === 'canonical') {
+          const link = getDuplicateMeta(child);
+          if (link) removeChild(head, link);
         }
       });
 


### PR DESCRIPTION
I realized when placing `link` with attribute `rel="canonical"` within `<MetaTags>`, the tag was duplicated each time it'd been modified.

So, I decided that support for this tag should be added, as it may be considered `meta` tag, though it's actually a `link` tag.
