### PR TITLE
meta tag instance return components instead of string

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -36,17 +36,18 @@ app.use((req, res) => {
             return;
           }
 
-          const meta = metaTagsInstance.renderToString();
+          const metaString = metaTagsInstance.renderToString();
+          const metaComponents = metaTagsInstance.toComponents();
+          console.log(metaComponents);
 
           const template = `
-            <!doctype html>
             <html lang="en">
             <head>
               <meta charSet="utf-8"/>
               <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
               <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-              ${meta}
+              ${metaString}
               <!-- Bootstrap CSS -->
               <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css" integrity="2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous">
 
@@ -56,8 +57,23 @@ app.use((req, res) => {
               <script src="http://localhost:9000/bundle.js"></script>
             </body>
           `;
+          const Html = (<html lang="en">
+            <head>
+              <meta charSet="utf-8"/>
+              <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+              <meta http-equiv="x-ua-compatible" content="ie=edge" />
+              {metaComponents}
+              <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css" integrity="2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous" />
+            </head>
+            <body>
+              <div id="app" dangerouslySetInnerHTML={{__html: reactString}} />
+              <script src="http://localhost:9000/bundle.js"></script>
+            </body>
+          </html>)
 
-        res.status(200).send(template)
+        //res.status(200).send(`<!doctype html>${template}`)
+        const htmlMarkup = ReactDomServer.renderToStaticMarkup(Html)
+        res.status(200).send(`<!doctype html>${htmlMarkup}`)
       } else {
         console.log('redirected');
         res.status(301).redirect('/')

--- a/src/meta_tags_server.js
+++ b/src/meta_tags_server.js
@@ -28,6 +28,9 @@ function MetaTagsServer(){
         ${canonicalLink}
         ${rest}
       `;
+    },
+    toComponents: function(){
+      return headElms;
     }
   }
 }


### PR DESCRIPTION
I am trying to return real react components (representing the meta tags) instead of just a string.
This is very important because if your HTML template is a react component itself, you will not be able to include the metas without wrapping them (which is not desirable).

I simply added this code to the meta tags server:
```
toComponents: function(){
      return headElms;
    }
```
The problem is that I miss the `removeDuplicateMetas` functionality and I end up with all metas in the head:

![screenshot from 2018-09-03 10-18-28](https://user-images.githubusercontent.com/284394/44962465-5dcb6000-af64-11e8-9a29-cbd64f08e80b.png)

I updated the example to be able to test this implementation. The Html template is now a pure react component. 

Can you help with implementing the dedupe functionality for the `toComponents` function?