### PR TITLE
add null check for children and extract

### DIFF
--- a/src/meta_tags.js
+++ b/src/meta_tags.js
@@ -24,6 +24,7 @@ class MetaTags extends Component {
     }
   }
   extractChildren() {
+    if(!this.context.children) return;
     const {extract} = this.context;
 
     if (extract) {
@@ -31,6 +32,7 @@ class MetaTags extends Component {
     }
   }
   handleChildrens() {
+    if(!this.props.children) return;
     const {children} = this.props;
 
     if (this.context.extract){


### PR DESCRIPTION
This will account for situations where asynchronous loading prevents document children elements from rendering right away. For example, if you are passing data from an api response as the initial state of a redux store and rendering components based on that store.