### PR TITLE
Fix type error in handleChildrens()

### DIFF
--- a/src/meta_tags.js
+++ b/src/meta_tags.js
@@ -54,9 +54,13 @@ class MetaTags extends Component {
       this.lastChildStr = childStr;
 
       const tempHead = this.temporaryElement.querySelector('.react-head-temp');
-      let childNodes = tempHead === null
-          ? []
-          : Array.prototype.slice.call(tempHead.children);
+
+      // .react-head-temp might not exist when triggered from async action
+      if (tempHead === null) {
+        return;
+      }
+
+      let childNodes = Array.prototype.slice.call(tempHead.children);
 
       const head = document.head;
       const headHtml = head.innerHTML;

--- a/src/meta_tags.js
+++ b/src/meta_tags.js
@@ -53,7 +53,10 @@ class MetaTags extends Component {
 
       this.lastChildStr = childStr;
 
-      let childNodes = Array.prototype.slice.call(this.temporaryElement.querySelector('.react-head-temp').children);
+      const tempHead = this.temporaryElement.querySelector('.react-head-temp');
+      let childNodes = tempHead === null
+          ? []
+          : Array.prototype.slice.call(tempHead.children);
 
       const head = document.head;
       const headHtml = head.innerHTML;


### PR DESCRIPTION
The lack of a null check in `handleChildrens()` can cause crashes in some cases (which I assume are related to asynchronous actions causing re-renders in the React tree of the application). This patch checks whether `Element.querySelector()` fails before trying to access properties expected in a DOM node in order to avoid a crash.