### PR TITLE
fix: use new context api

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,5 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
-  "dependencies": {
-    "prop-types": "^15.6.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "webpack-dev-server": "^3.1.7"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0.0 || ^ 16.0.0",
-    "react-dom": "^0.14 || ^15.0.0 || ^ 16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import MetaTagsContext from './meta_tags_context';
+import MetaTagsContext, {MetaContext} from './meta_tags_context';
 import MetaTags from './meta_tags';
 import ReactTitle from './react_title';
 
 export default MetaTags;
-export {MetaTags, MetaTagsContext, ReactTitle};
+export {MetaContext, MetaTags, MetaTagsContext, ReactTitle};

--- a/src/meta_tags.js
+++ b/src/meta_tags.js
@@ -1,14 +1,13 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {getDuplicateTitle, getDuplicateCanonical, getDuplicateMeta, appendChild, removeChild} from './utils';
+import { MetaContext } from './meta_tags_context';
 
 
 /** An wrapper component to wrap element which need to shifted to head **/
 class MetaTags extends Component {
-  static contextTypes = {
-    extract: PropTypes.func
-  };
+  static contextTypes = MetaContext;
+
   componentDidMount() {
     this.temporaryElement = document.createElement('div');
     this.handleChildrens();

--- a/src/meta_tags_context.js
+++ b/src/meta_tags_context.js
@@ -1,17 +1,24 @@
-import {Component, Children} from 'react';
-import PropTypes from 'prop-types';
+import React, {Component, Children, createContext} from 'react';
+
+const MetaContext = createContext({
+  extract: () => {},
+});
 
 /** context class which passes extract fuunction to MetaTags Component **/
-class MetaTagsContext extends Component {
-  static childContextTypes = {
-    extract: PropTypes.func
-  }
-  getChildContext() {
-    return {extract: this.props.extract};
-  }
+class MetaContextProviderWrapper extends Component {
   render() {
-    return Children.only(this.props.children);
+    return (
+      <MetaContext.Provider
+        value={{
+          extract: this.props.extract,
+        }}
+      >
+        {Children.only(this.props.children)}
+      </MetaContext.Provider>
+    );
   }
 }
 
-export default MetaTagsContext;
+export {MetaContext};
+
+export default MetaContextProviderWrapper;

--- a/src/react_title.js
+++ b/src/react_title.js
@@ -1,11 +1,7 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import MetaTags from './meta_tags';
 
 class ReactTitle extends Component {
-  static propTypes = {
-    title: PropTypes.string
-  }
   render() {
     return (<MetaTags>
       <title>


### PR DESCRIPTION
This PR fixes the following:

- Use the newer context api to remove console warnings/errors
- Export the context object for using `Consumer`
- upgrade the react peer dependency to ensure the latest react is used for newer apis
- Remove the prop-types package and its usage